### PR TITLE
remote jwks cluster needs to match gstatic.com URL

### DIFF
--- a/envoy_iap.yaml
+++ b/envoy_iap.yaml
@@ -42,7 +42,7 @@ static_resources:
                   remote_jwks:
                     http_uri:
                       uri: https://www.gstatic.com/iap/verify/public_key-jwk
-                      cluster: jwt.www.googleapis.com|443
+                      cluster: jwt.www.gstatic.com|443
                       timeout:
                         seconds: 5                     
                   from_headers:
@@ -69,13 +69,13 @@ static_resources:
               socket_address:
                 address: localhost
                 port_value: 50051
-  - name: jwt.www.googleapis.com|443
+  - name: jwt.www.gstatic.com|443
     type: LOGICAL_DNS
     dns_lookup_family: V4_ONLY
     connect_timeout: 2s
     lb_policy: ROUND_ROBIN
     load_assignment:
-      cluster_name: jwt.www.googleapis.com|443
+      cluster_name: jwt.www.gstatic.com|443
       endpoints:
       - lb_endpoints:
         - endpoint:

--- a/envoy_iap.yaml
+++ b/envoy_iap.yaml
@@ -81,7 +81,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: www.googleapis.com
+                address: www.gstatic.com
                 port_value: 443
     transport_socket:
       name: envoy.transport_sockets.tls


### PR DESCRIPTION
I tried this on an envoy sidecar in a GKE cluster protected by IAP and the jwks kept failing to get certs and got 404.  Switching the endpoint to gstatic.com seemed to fix this issue.